### PR TITLE
Enhance GitHubParsed so that it can handle URLs with ports and additional path segment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </description>
   <url>https://github.com/Hygieia/${repository.name}</url>
   <packaging>jar</packaging>
-  <version>3.2.4-SNAPSHOT</version>
+  <version>3.2.5-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capitalone/dashboard/model/GitHubParsed.java
+++ b/src/main/java/com/capitalone/dashboard/model/GitHubParsed.java
@@ -52,6 +52,17 @@ public class GitHubParsed {
             baseApiUrl = protocol + "://" + PUBLIC_GITHUB_BASE_API;
             apiUrl = protocol + "://" + PUBLIC_GITHUB_REPO_HOST + path;
             graphQLUrl = protocol + "://" + PUBLIC_GITHUB_GRAPHQL;
+        } else if (parts.length>3) {
+            orgName = parts[parts.length-2];
+            repoName = parts[parts.length-1];
+            String baseUrl = protocol + "://" + host;
+            if (u.getPort()>0) baseUrl += ":" + u.getPort();
+            for (int i=1; i<parts.length-2; i++) {
+                baseUrl += "/" + parts[i];
+            }
+            apiUrl = baseUrl + SEGMENT_API + "/" + orgName + "/" + repoName;
+            baseApiUrl = baseUrl + BASE_API;
+            graphQLUrl = baseUrl + SEGMENT_GRAPHQL;
         } else {
             apiUrl = protocol + "://" + host + SEGMENT_API + path;
             baseApiUrl = protocol + "://" + host + BASE_API;


### PR DESCRIPTION
The current code only allows github URL in the form of http(s)://{host}/{organization}/{repository}, do not allow a port number or additional segments, such as https://hygieia-emulator:8112/github/org/repo. The change allows paths with additional segment to work.
